### PR TITLE
Update testem dependency to 0.7.7

### DIFF
--- a/package.json
+++ b/package.json
@@ -23,7 +23,7 @@
     "phantomjs"
   ],
   "dependencies": {
-    "testem": "0.6.22",
+    "testem": "0.7.7",
     "chokidar": "0.8.1",
     "async": "0.9.0"
   },


### PR DESCRIPTION
This is needed for phantomjs 2.0 work with testem.  2.0 is the version that ships with Arch Linux now.  I tested 1.9.8 (i.e. latest nodejs version) and that seems to work without problems as well!
